### PR TITLE
Add a grid view toggle for game list tables using CSS

### DIFF
--- a/src/components/Explore.js
+++ b/src/components/Explore.js
@@ -49,6 +49,7 @@ function Explore(props) {
   const [expandedPara, expandedParaSetter] = useState([]);
   const [sorting, setSorting] = useState([{ id: "gameName", desc: false }]);
   const [columnFilters, setColumnFilters] = useState([]);
+  const [gridView, gridViewSetter] = useStorageState("grid-view", false);
   const { metaGame } = useParams();
   const { t, i18n } = useTranslation();
   addResource(i18n.language);
@@ -1431,6 +1432,30 @@ function Explore(props) {
               </div>
             </div>
           </div>
+          <div className="level-item field has-addons is-centered">
+            <div className="control">
+              <button
+                className={gridView ? "button is-small apButtonNeutral" : "button is-small apButton"}
+                onClick={() => gridViewSetter(false)}
+              >
+                <span className="icon is-small">
+                  <i className="fa fa-th-list"></i>
+                </span>
+                <span>Table</span>
+              </button>
+            </div>
+            <div className="control">
+              <button
+                className={gridView ? "button is-small apButton" : "button is-small apButtonNeutral"}
+                onClick={() => gridViewSetter(true)}
+              >
+                <span className="icon is-small">
+                  <i className="fa fa-th-large"></i>
+                </span>
+                <span>Grid</span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </>
@@ -1499,7 +1524,7 @@ function Explore(props) {
               </ReactMarkdown>
               <div className="container">
                 {tableNavigation}
-                <table className="table apTable">
+                <table className={gridView ? "table apTable gameGrid" : "table apTable"}>
                   <thead>
                     {table.getHeaderGroups().map((headerGroup) => (
                       <tr key={headerGroup.id} className="stickyHeader">

--- a/src/components/MetaContainer/TableExplore.js
+++ b/src/components/MetaContainer/TableExplore.js
@@ -52,6 +52,7 @@ function TableExplore({ toggleStar, handleChallenge, updateSetter, ...props }) {
   const [columnFilters, setColumnFilters] = useState([]);
   const [showState, showStateSetter] = useStorageState("allgames-show", 10);
   const [ddSelected, ddSelectedSetter] = useState("");
+  const [gridView, gridViewSetter] = useStorageState("grid-view", false);
   addResource(i18n.language);
 
   useEffect(() => {
@@ -667,6 +668,30 @@ function TableExplore({ toggleStar, handleChallenge, updateSetter, ...props }) {
               </div>
             </div>
           </div>
+          <div className="level-item field has-addons is-centered">
+            <div className="control">
+              <button
+                className={gridView ? "button is-small apButtonNeutral" : "button is-small apButton"}
+                onClick={() => gridViewSetter(false)}
+              >
+                <span className="icon is-small">
+                  <i className="fa fa-th-list"></i>
+                </span>
+                <span>Table</span>
+              </button>
+            </div>
+            <div className="control">
+              <button
+                className={gridView ? "button is-small apButton" : "button is-small apButtonNeutral"}
+                onClick={() => gridViewSetter(true)}
+              >
+                <span className="icon is-small">
+                  <i className="fa fa-th-large"></i>
+                </span>
+                <span>Grid</span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </>
@@ -679,7 +704,7 @@ function TableExplore({ toggleStar, handleChallenge, updateSetter, ...props }) {
       </div>
       <div className="container">
         {tableNavigation}
-        <table className="table apTable">
+        <table className={gridView ? "table apTable gameGrid" : "table apTable"}>
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id} className="stickyHeader">
@@ -789,7 +814,7 @@ function TableExplore({ toggleStar, handleChallenge, updateSetter, ...props }) {
                                     </>
                                   ),
                                 null
-                              )}
+                            )}
                           </>
                         )}
                       </>

--- a/src/index.css
+++ b/src/index.css
@@ -244,6 +244,8 @@ strong {
 }
 
 /* Only used to colour buttons until I can figure out how to override Bulma colours */
+.tableNav .apButton,
+.tableNav .apButton:hover,
 .apButton {
   background: linear-gradient(
     180deg,
@@ -982,6 +984,85 @@ span.hardTime::after {
   .tabs.is-toggle a:hover {
     background-color: var(--secondary-color-3-bg);
     color: var(--main-font-color);
+  }
+
+  /* Game tables conversion to grid via css */
+  table.gameGrid.apTable {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+  }
+
+  table.gameGrid.apTable tr {
+      display: inline-flex;
+      flex-direction:column;
+      width: 20%;
+      background-color: var(--main-bg-color)!important;
+      padding: 1em;
+      vertical-align:top;
+  }
+
+  @media screen and (max-width: 768px) {
+      table.gameGrid.apTable tr {
+	  width: unset;
+      }
+  }
+
+  table.gameGrid.apTable thead {
+      display:none;
+  }
+
+  table.gameGrid.apTable td {
+      display: block;
+      border: none!important;
+  }
+
+  table.gameGrid.apTable td:nth-child(1) {
+      order: 1;
+  }
+  table.gameGrid.apTable td:nth-child(1) a {
+      color: var(--main-heading-color)!important;
+      font-size: 20px!important;
+      font-weight: var(--bulma-subtitle-weight)!important;
+      text-decoration: none!important;
+      font-family: Cardo, serif;
+  }
+
+  table.gameGrid.apTable td:nth-child(2) {
+      text-align:center!important;
+      order: 5;
+  }
+  table.gameGrid.apTable td:nth-child(2) a {
+      color: var(--secondary-font-color);
+      text-decoration:none;
+      text-align:center!important;
+  }
+
+  table.gameGrid.apTable td:nth-child(3) {
+      background-color: rgba(255,255,255,0.5)!important;
+      order: 4;
+  }
+
+  table.gameGrid.apTable td:nth-child(4) {
+      order: 3;
+  }
+
+  table.gameGrid.apTable td:nth-child(5) {
+      max-height: 6em;
+      overflow: scroll;
+      order: 6;
+  }
+
+  table.gameGrid.apTable td:nth-child(6) {
+      color: var(--secondary-font-color)!important;
+      order: 2;
+  }
+  table.gameGrid.apTable td:nth-child(6):has(> a) {
+      display: none;
+  }
+
+  table.gameGrid.apTable td:nth-child(n+7) {
+      display: none;
   }
 
   /* Game board customimzation for light/dark mode! */


### PR DESCRIPTION
I liked the About page layout so I wrote some CSS to lay out the Games page table(s) the same way, plus a toggle button to switch views.  Here are some screenshots so you don't have to fire it up to know what I'm talking about.

The main game search:
![Screenshot 2025-06-30 at 6 22 28 PM](https://github.com/user-attachments/assets/232b6a81-06ac-41a7-a6e1-a807e4994ae3)

----

A new hotness search, with the relevant value included in the grid view:
![Screenshot 2025-06-30 at 6 23 18 PM](https://github.com/user-attachments/assets/ec07097a-7ca3-43ba-a845-cbd3c476454f)

----

Another new hotness search, this time at mobile dimensions:
![Screenshot 2025-06-30 at 6 24 15 PM](https://github.com/user-attachments/assets/4dacdc9d-6b69-47a3-abdd-61171a3a82ac)
