### PR TITLE
Add presets from the default palette to the color picker for custom palettes

### DIFF
--- a/src/components/UserSettingsModal.js
+++ b/src/components/UserSettingsModal.js
@@ -635,6 +635,8 @@ function UserSettingsModal(props) {
     }
   };
 
+  /* Default palette colors from the renderer. */
+  const presetColors = ["#e31a1c", "#1f78b4", "#33a02c", "#ffff99", "#6a3d9a", "#ff7f00", "#b15928", "#fb9a99", "#a6cee3", "#b2df8a", "#fdbf6f", "#cab2d6"];
   console.log(language);
 
   return (
@@ -1222,10 +1224,22 @@ function UserSettingsModal(props) {
                 Choose a colour
               </label>
               <div className="control" id="colorSelect">
-                <HexColorPicker
-                  color={selectedColour}
-                  onChange={selectedColourSetter}
-                />
+                <div className="picker">
+                  <HexColorPicker
+                    color={selectedColour}
+                    onChange={selectedColourSetter}
+                  />
+                  <div className="picker-swatches">
+                    {presetColors.map((presetColor) => (
+                      <button
+                        key={presetColor}
+                        className="picker-swatch"
+                        style={{ background: presetColor }}
+                        onClick={() => selectedColourSetter(presetColor)}
+                      />
+                    ))}
+                  </div>
+                </div>
                 <HexColorInput
                   color={selectedColour}
                   onChange={selectedColourSetter}

--- a/src/index.css
+++ b/src/index.css
@@ -1061,6 +1061,21 @@ span.hardTime::after {
       padding: 2px 2px 0 2px;
   }
 
+  /* style text input for palettes */
+  #colorSelect input {
+      display: block;
+      box-sizing: border-box;
+      width: 6em;
+      margin: 20px 55px 0;
+      padding: 3px;
+      border: 1px solid #888;
+      border-radius: 3px;
+      background: var(--tag-background-color);
+      outline: none;
+      font-family: var(--bulma-family-code);
+      text-align: center;
+  }
+
   /* Game board customimzation for light/dark mode! */
   /* gridlines for cobweb boards */
   /* div._meta_agere g#gridlines circle:not([class]) {

--- a/src/index.css
+++ b/src/index.css
@@ -1059,9 +1059,10 @@ span.hardTime::after {
       display: inline-block;
       white-space: nowrap;
       padding: 2px 2px 0 2px;
+      font-weight: bold;
   }
 
-  /* style text input for palettes */
+  /* restyle text input for palettes */
   #colorSelect input {
       display: block;
       box-sizing: border-box;
@@ -1074,6 +1075,40 @@ span.hardTime::after {
       outline: none;
       font-family: var(--bulma-family-code);
       text-align: center;
+  }
+
+  /* adding preset colors to palette picker */
+  #colorSelect .picker {
+      width: 225px;
+      background: var(--tag-background-color);
+      border-radius: 9px;
+  }
+
+  #colorSelect .picker .react-colorful {
+      width: auto;
+  }
+
+  #colorSelect .picker .react-colorful .react-colorful__hue {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+  }
+
+  #colorSelect .picker-swatches {
+      display: flex;
+      padding: 12px;
+      flex-wrap: wrap;
+      justify-content: space-around;
+  }
+
+  #colorSelect .picker-swatch {
+      width: 24px;
+      height: 24px;
+      margin: 4px;
+      border: none;
+      padding: 0;
+      border-radius: 4px;
+      cursor: pointer;
+      outline: none;
   }
 
   /* Game board customimzation for light/dark mode! */


### PR DESCRIPTION
This is based on an example [at react-colorful](https://codesandbox.io/s/bekry?file=/src/SwatchesPicker.js).  You should be able to see it with my changes [here](https://codesandbox.io/p/devbox/react-colorful-swatches-forked-dt6ksr).